### PR TITLE
Fixed incompatibility with influxdb >4.0.0

### DIFF
--- a/flask_influxdb.py
+++ b/flask_influxdb.py
@@ -1,46 +1,34 @@
 import influxdb
-from flask import current_app
 
 try:
     from flask import _app_ctx_stack as stack
 except ImportError:
     from flask import _request_ctx_stack as stack
 
-class InfluxDB(object):
 
+class InfluxDB(object):
     def __init__(self, app=None):
+        self.client_init_kwargs = {}
         self.app = app
         if app is not None:
             self.init_app(app)
 
     def init_app(self, app):
-        app.config.setdefault('INFLUXDB_HOST','localhost')
-        app.config.setdefault('INFLUXDB_PORT','8086')
-        app.config.setdefault('INFLUXDB_USER','root')
-        app.config.setdefault('INFLUXDB_PASSWORD','root')
-        app.config.setdefault('INFLUXDB_DATABASE',None)
-        app.config.setdefault('INFLUXDB_SSL',False)
-        app.config.setdefault('INFLUXDB_VERIFY_SSL',False)
-        app.config.setdefault('INFLUXDB_TIMEOUT',None)
-        app.config.setdefault('INFLUXDB_USE_UDP',False)
-        app.config.setdefault('INFLUXDB_UDP_PORT',4444)
-
         if hasattr(app, 'teardown_appcontext'):
             app.teardown_appcontext(self.teardown)
         else:
             app.teardown_request(self.teardown)
 
+        # Create init kwargs for InfluxDBClient by transforming all
+        # INFLUXDB_X = Y directives to a dict with: {X.lower(): Y}
+        for k, v in app.config.items():
+            if k.startswith('INFLUXDB_'):
+                self.client_init_kwargs[
+                    k.replace('INFLUXDB_', '').lower()] = v
+
     def connect(self):
-        return influxdb.InfluxDBClient(current_app.config['INFLUXDB_HOST'],
-                                       current_app.config['INFLUXDB_PORT'],
-                                       current_app.config['INFLUXDB_USER'],
-                                       current_app.config['INFLUXDB_PASSWORD'],
-                                       current_app.config['INFLUXDB_DATABASE'],
-                                       current_app.config['INFLUXDB_SSL'],
-                                       current_app.config['INFLUXDB_VERIFY_SSL'],
-                                       current_app.config['INFLUXDB_TIMEOUT'],
-                                       current_app.config['INFLUXDB_USE_UDP'],
-                                       current_app.config['INFLUXDB_UDP_PORT'])
+        return influxdb.InfluxDBClient(**self.client_init_kwargs)
+
     def teardown(self, exception):
         """This is really a sub in case a influxdb input actually does need
         to be able to be torn down"""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='Flask-InfluxDB',
-    version='0.1',
+    version='0.2',
     url='http://github.com/ombitron/flask-influxdb',
     license='BSD',
     author='Brennan Ashton',


### PR DESCRIPTION
Also handle InfluxDBClient init kwargs dynamically to prevent future incompatibility bugs like this. Note that this breaks current configurations since the directive for "username" is now INFLUXDB_USERNAME instead of INFLUXDB_USER.

Fixes #1