### PR TITLE
Incompatibility fix with influxdb 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,68 @@
 Flask-InfluxDB
 ==============
+Extension to add InfluxDB support to Flask framework [(external documentation)](https://flask-influxdb.readthedocs.org/en/latest/).
 
-Adds InfluxDB support to Flask
+## Installation
+Install the extension via *pip*:
 
-See docs 
+```python
+$ pip install Flask-InfluxDB
+```
 
-[![Documentation Status](https://readthedocs.org/projects/flask-influxdb/badge/?version=latest)](https://flask-influxdb.readthedocs.org/en/latest/)
+## Set Up
+Flask-InfluxDB can be accessed via ``InfluxDB`` class:
+
+```python
+from flask import Flask
+from flask_influxdb import InfluxDB
+
+app = Flask(__name__)
+influx_db = InfluxDB(app=app)
+```
+
+Delayed configuration of ``InfluxDB`` is also supported using the **init_app** method:
+
+```python
+influx_db = InfluxDB()
+
+app = Flask(__name__)
+influxdb.init_app(app=app)
+```
+
+The ``InfluxDB.connection`` instance provides the functionality of
+``InfluxDBClient``. ``InfluxDB`` may provide better wrappers to extend this class.
+
+An included example demonstrates how a database can be created and how data can be written and queried.
+
+
+## Configuring Flask-InfluxDB
+The following configuration values can be set for Flask-InfluxDB extension:
+
+```
+INFLUXDB_HOST               Host for the InfluxDB host. Default is localhost.
+
+INFLUXDB_PORT               InfluxDB HTTP API port. Default is 8086.
+
+INFLUXDB_USER               InfluxDB server user. Default is root.
+
+INFLUXDB_PASSWORD           InfluxDB server password. Default is root.
+
+INFLUXDB_DATABASE           Optional database to connect to.  Defaults to None.
+
+INFLUXDB_SSL                Enables using HTTPS instead of http. Defaults to False.
+
+INFLUXDB_VERIFY_SSL         Enables checking HTTPS certificate. Defaults to False.
+
+INFLUXDB_RETRIES            Number of retries your client will try before aborting, 0 indicates try until success.
+                            Defaults to 3
+
+INFLUXDB_TIMEOUT            Sets request timeout. Defaults to None.
+
+INFLUXDB_USE_UDP            Use the UDP interfaces instead of http. Defaults to False.
+
+INFLUXDB_UDP_PORT           UDP api port number. Defaults to 4444.
+
+INFLUXDB_PROXIES            HTTP(S) proxy to use for Requests. Defaults to None.
+
+INFLUXDB_POOL_SIZE          urllib3 connection pool size. Defaults to 10.
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Install the extension via pip::
 Set Up
 ------
 
-Influxdb is accessed via ``InfluxDB``::
+Influxdb can be accessed via ``InfluxDB`` class::
 
     from flask import Flask
     from flask_influxdb import InfluxDB
@@ -21,23 +21,21 @@ Influxdb is accessed via ``InfluxDB``::
     app = Flask(__name__)
     influx_db = InfluxDB(app=app)
 
-Delayed configuration of ``InfluxDB`` is also support using **init_app** method::
+Delayed configuration of ``InfluxDB`` is also supported using the **init_app** method::
 
     influx_db = Influxdb()
 
     app = Flask(__name__)
     influxdb.init_app(app=app)
 
-Currently the ``InfluxDB.connection`` instance provides the functionality of
-``InfluxDBClient`` . InfluxDB may later provide better wrappers to extend this class.
+Currently the ``InfluxDB.connection`` instance provides the functionality of ``InfluxDBClient`` . InfluxDB may provide better wrappers to extend this class.
 
-An included examples shows how a database can be created and data written and queried.
-
+An included example shows how a database can be created and how data can be written and queried.
 
 Configuring Flask-InfluxDB
 --------------------------
 
-The following configuration values exist for Flask-InfluxDB:
+The following configuration values can be set for Flask-InfluxDB extension:
 
 .. tabularcolumns:: |p{6.5cm|p{8.5cm}|
 
@@ -68,5 +66,4 @@ The following configuration values exist for Flask-InfluxDB:
 ``INFLUXDB_PROXIES``            HTTP(S) proxy to use for Requests. Defaults to None.
 
 ``INFLUXDB_POOL_SIZE``          urllib3 connection pool size. Defaults to 10.
-
 =============================== ==================================================================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Flask-InfluxDB
 ==========================================
 
-.. module:: flask.ext.influxdb
+.. module:: flask_influxdb
 
 Installation
 ------------
@@ -16,17 +16,17 @@ Set Up
 Influxdb is accessed via ``InfluxDB``::
 
     from flask import Flask
-    from flask.ext.influxdb import InfluxDB
+    from flask_influxdb import InfluxDB
 
     app = Flask(__name__)
-    influx_db = InfluxDB(app)
+    influx_db = InfluxDB(app=app)
 
 Delayed configuration of ``InfluxDB`` is also support using **init_app** method::
 
     influx_db = Influxdb()
 
     app = Flask(__name__)
-    influxdb.init_app(app)
+    influxdb.init_app(app=app)
 
 Currently the ``InfluxDB.connection`` instance provides the functionality of
 ``InfluxDBClient`` . InfluxDB may later provide better wrappers to extend this class.
@@ -56,10 +56,17 @@ The following configuration values exist for Flask-InfluxDB:
 
 ``INFLUXDB_VERIFY_SSL``         Enables checking HTTPS certificate. Defaults to False.
 
+``INFLUXDB_RETRIES``            Number of retries your client will try before aborting, 0 indicates try until success.
+                                Defaults to 3
+
 ``INFLUXDB_TIMEOUT``            Sets request timeout. Defaults to None.
 
 ``INFLUXDB_USE_UDP``            Use the UDP interfaces instead of http. Defaults to False.
 
 ``INFLUXDB_UDP_PORT``           UDP api port number. Defaults to 4444.
+
+``INFLUXDB_PROXIES``            HTTP(S) proxy to use for Requests. Defaults to None.
+
+``INFLUXDB_POOL_SIZE``          urllib3 connection pool size. Defaults to 10.
 
 =============================== ==================================================================

--- a/example/example.py
+++ b/example/example.py
@@ -1,21 +1,50 @@
+from flask_influxdb import InfluxDB
 from flask import Flask, render_template
-from flask.ext.influxdb import InfluxDB
-
 
 app = Flask(__name__)
 app.config.from_pyfile('example.cfg')
-influx_db = InfluxDB(app)
+influx_db = InfluxDB(app=app)
+
 
 @app.route('/newdb/<dbname>')
 def newdb(dbname):
     dbcon = influx_db.connection
     dbcon.create_database(dbname)
+    return ''
+
 
 @app.route('/write/<dbname>')
 def write(dbname):
+    data_measurement = 'testseries'
+    data_tags = ['time', 'value_1', 'value_2', 'value_3']
+
     dbcon = influx_db.connection
-    dbcon.switch_db(dbname)
-    dbcon.write_points([{"points":[[1],[2],[3]],"name":"testseries","columns":["value"]}])
-    tabledata = dbcon.query('select value from testseries;')
-    return render_template('table.html',data=tabledata[0])
+    dbcon.switch_database(database=dbname)
+    dbcon.write_points([
+        {
+            "fields": {
+                'value_1': 0.5,
+                'value_2': 1,
+                'value_3': 1.8858
+            },
+            "tags": {
+                'tag_1': 'tag_string',
+                'tag_2': 'tag_string'
+            },
+            "measurement": "testseries"
+        }
+    ])
+    tabledata = dbcon.query('SELECT {0} from {1}'.format(', '.join(data_tags), data_measurement))
+
+    data_points = []
+    for measurement, tags in tabledata.keys():
+        for p in tabledata.get_points(measurement=measurement, tags=tags):
+            data_points.append(p)
+
+    return render_template('table.html',
+                           measurement=data_measurement,
+                           columns=data_tags,
+                           points=data_points)
+
+
 app.run()

--- a/example/templates/table.html
+++ b/example/templates/table.html
@@ -1,23 +1,23 @@
 <html>
 <head>
-	<title>Table</title>
+    <title>Table</title>
 </head>
 <body>
-<h1>{{data.name}}</h1>
+<h1>{{ measurement }}</h1>
 <table>
-  <tr>
-  {% for heading in data.columns %}
-    <th>{{ heading }}</th>
-  {% endfor %}
-  </tr>
-{% for row in data.points %}
-  <tr>
-  {% set rowloop = loop %}
-  {% for cell in row %}
-    <td id="cell-{{ rowloop.index }}-{{ loop.index }}>{{ cell }}</td>
-  {% endfor %}
-  </tr>
-{% endfor %}
+    <tr>
+        {% for heading in columns %}
+            <th>{{ heading }}</th>
+        {% endfor %}
+    </tr>
+    {% for row in points %}
+        <tr>
+            {% set rowloop = loop %}
+            {% for heading in columns %}
+                <td id="cell-{{ rowloop.index }}-{{ loop.index }}">{{ row[heading] }}</td>
+            {% endfor %}
+        </tr>
+    {% endfor %}
 </table>
 </body>
 </html>

--- a/flask_influxdb.py
+++ b/flask_influxdb.py
@@ -6,24 +6,36 @@ try:
 except ImportError:
     from flask import _request_ctx_stack as stack
 
-class InfluxDB(object):
 
+class InfluxDB(object):
     def __init__(self, app=None):
+        """
+        Class constructor
+        :param app: Flask Application object
+        """
         self.app = app
         if app is not None:
             self.init_app(app)
 
     def init_app(self, app):
-        app.config.setdefault('INFLUXDB_HOST','localhost')
-        app.config.setdefault('INFLUXDB_PORT','8086')
-        app.config.setdefault('INFLUXDB_USER','root')
-        app.config.setdefault('INFLUXDB_PASSWORD','root')
-        app.config.setdefault('INFLUXDB_DATABASE',None)
-        app.config.setdefault('INFLUXDB_SSL',False)
-        app.config.setdefault('INFLUXDB_VERIFY_SSL',False)
-        app.config.setdefault('INFLUXDB_TIMEOUT',None)
-        app.config.setdefault('INFLUXDB_USE_UDP',False)
-        app.config.setdefault('INFLUXDB_UDP_PORT',4444)
+        """
+        Initialize extension for application
+        :param app: Flask Application object
+        :return:
+        """
+        app.config.setdefault('INFLUXDB_HOST', 'localhost')
+        app.config.setdefault('INFLUXDB_PORT', '8086')
+        app.config.setdefault('INFLUXDB_USER', 'root')
+        app.config.setdefault('INFLUXDB_PASSWORD', 'root')
+        app.config.setdefault('INFLUXDB_DATABASE', None)
+        app.config.setdefault('INFLUXDB_SSL', False)
+        app.config.setdefault('INFLUXDB_VERIFY_SSL', False)
+        app.config.setdefault('INFLUXDB_RETRIES', 3)
+        app.config.setdefault('INFLUXDB_TIMEOUT', None)
+        app.config.setdefault('INFLUXDB_USE_UDP', False)
+        app.config.setdefault('INFLUXDB_UDP_PORT', 4444)
+        app.config.setdefault('INFLUXDB_PROXIES', None)
+        app.config.setdefault('INFLUXDB_POOL_SIZE', 10)
 
         if hasattr(app, 'teardown_appcontext'):
             app.teardown_appcontext(self.teardown)
@@ -31,16 +43,26 @@ class InfluxDB(object):
             app.teardown_request(self.teardown)
 
     def connect(self):
-        return influxdb.InfluxDBClient(current_app.config['INFLUXDB_HOST'],
-                                       current_app.config['INFLUXDB_PORT'],
-                                       current_app.config['INFLUXDB_USER'],
-                                       current_app.config['INFLUXDB_PASSWORD'],
-                                       current_app.config['INFLUXDB_DATABASE'],
-                                       current_app.config['INFLUXDB_SSL'],
-                                       current_app.config['INFLUXDB_VERIFY_SSL'],
-                                       current_app.config['INFLUXDB_TIMEOUT'],
-                                       current_app.config['INFLUXDB_USE_UDP'],
-                                       current_app.config['INFLUXDB_UDP_PORT'])
+        """
+        Connect to InfluxDB using configuration parameters
+        :return: InfluxDBClient object
+        """
+        return influxdb.InfluxDBClient(
+            host=current_app.config['INFLUXDB_HOST'],
+            port=current_app.config['INFLUXDB_PORT'],
+            username=current_app.config['INFLUXDB_USER'],
+            password=current_app.config['INFLUXDB_PASSWORD'],
+            database=current_app.config['INFLUXDB_DATABASE'],
+            ssl=current_app.config['INFLUXDB_SSL'],
+            verify_ssl=current_app.config['INFLUXDB_VERIFY_SSL'],
+            timeout=current_app.config['INFLUXDB_TIMEOUT'],
+            retries=current_app.config['INFLUXDB_RETRIES'],
+            use_udp=current_app.config['INFLUXDB_USE_UDP'],
+            udp_port=current_app.config['INFLUXDB_UDP_PORT'],
+            proxies=current_app.config['INFLUXDB_PROXIES'],
+            pool_size=current_app.config['INFLUXDB_POOL_SIZE']
+        )
+
     def teardown(self, exception):
         """This is really a sub in case a influxdb input actually does need
         to be able to be torn down"""
@@ -50,6 +72,10 @@ class InfluxDB(object):
 
     @property
     def connection(self):
+        """
+        InfluxDBClient object
+        :return:
+        """
         ctx = stack.top
         if ctx is not None:
             if not hasattr(ctx, 'influxdb_db'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+influxdb==5.0.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='Flask-InfluxDB',
-    version='0.1',
+    version='0.2',
     url='http://github.com/ombitron/flask-influxdb',
     license='BSD',
     author='Brennan Ashton',
@@ -18,7 +18,7 @@ setup(
     platforms='any',
     install_requires=[
         'Flask',
-        'influxdb',
+        'influxdb==5.0.0',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
There is an incompatibility issue with influxdb 5.0.0 library because there are new parameters for the InfluxClientDB class.

Since the variables are not specified during the instance creation on the connect() method, writing points fail when using default values. This fix adds also new parameters for influxdb 5.0.0.